### PR TITLE
Add file_exclude_patterns/drives_include_patterns

### DIFF
--- a/SublimeFiles.sublime-settings
+++ b/SublimeFiles.sublime-settings
@@ -2,4 +2,8 @@
     //The command to execute to open a terminal.
     //Program will append the directory to open to the end of term_command.
     "term_command": "open -a Terminal "
+
+    // Filter for Drives and files
+    // "drives_include_patterns": ["c:\\"],
+    // "file_exclude_patterns": ["*.pyc"]
 }


### PR DESCRIPTION
Hi, first sorry for my bad English!
1. I get trouble with Removable media/devices on MS Windows when I call this Plugin at first time. Hence, i added "drives_include_patterns" settings in order to select driver/devices manually.
2. Just for fun I added “file_exclude_patterns” settings in order to ignore some files like "*.pyc"
