### PR TITLE
Add Packages Directory to the standard selections

### DIFF
--- a/sublime_files.py
+++ b/sublime_files.py
@@ -31,7 +31,8 @@ class SublimeFilesCommand(sublime_plugin.WindowCommand):
 
     # function for showing panel for changing directories / opening files
     def open_navigator(self):
-        self.dir_files = ['[' + os.getcwdu() + ']', bullet + ' Directory actions', '..' + os.sep, '~' + os.sep]
+        self.dir_files = ['[' + os.getcwdu() + ']', bullet + ' Directory actions',
+                bullet + ' Packages Directory', '..' + os.sep, '~' + os.sep]
 
         # annoying way to deal with windows
         if sublime.platform() == 'windows':
@@ -78,6 +79,8 @@ class SublimeFilesCommand(sublime_plugin.WindowCommand):
                 os.chdir(option)
             elif option == bullet + ' To current view':
                 os.chdir(os.path.dirname(self.window.active_view().file_name()))
+            elif option == bullet + ' Packages Directory':
+                os.chdir(sublime.packages_path())
             elif option.startswith(bullet + ' To bookmark'):
                 os.chdir(self.bookmark)
             else:


### PR DESCRIPTION
Well, this is just something I think that was missing, feel free to merge.

Other interesting things (paths) that I could not really find when scanning the code:
- Project root directory(/ies)
- Costum paths you are browsing often (e.g. added by a setting)

Of course, all of this is "optional" and kinda user-depended but they could be added as an option and I don't see anything against the setting thing.
