### PR TITLE
Corrected error in ST3

### DIFF
--- a/sublime_files.py
+++ b/sublime_files.py
@@ -45,7 +45,7 @@ class SublimeFilesCommand(sublime_plugin.WindowCommand):
 
         for element in os.listdir(os.getcwd()):
             ignore_element = False
-            if sel.ignore_list:
+            if self.ignore_list:
                 for ignore_pattern in self.ignore_list:
                     if fnmatch(element, ignore_pattern):
                         ignore_element = True

--- a/sublime_files.py
+++ b/sublime_files.py
@@ -45,10 +45,11 @@ class SublimeFilesCommand(sublime_plugin.WindowCommand):
 
         for element in os.listdir(os.getcwd()):
             ignore_element = False
-            for ignore_pattern in self.ignore_list:
-                if fnmatch(element, ignore_pattern):
-                    ignore_element = True
-                    break
+            if sel.ignore_list:
+                for ignore_pattern in self.ignore_list:
+                    if fnmatch(element, ignore_pattern):
+                        ignore_element = True
+                        break
             if not ignore_element:
                 fullpath = os.path.join(os.getcwd(), element)
                 if os.path.isdir(fullpath):


### PR DESCRIPTION
When running SublimeFiles in ST3, I had the following error:

```
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 524, in run_
    return self.run(**args)
  File "/Users/chadrien/Library/Application Support/Sublime Text 3/Packages/SublimeFiles/sublime_files.py", line 30, in run
    self.open_navigator()
  File "/Users/chadrien/Library/Application Support/Sublime Text 3/Packages/SublimeFiles/sublime_files.py", line 49, in open_navigator
    for ignore_pattern in self.ignore_list:
TypeError: 'NoneType' object is not iterable
```

Problem was simply a for…in started whithout checking the var is empty or not.
