### PR TITLE
New configuration option "start_directory"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ There are a few notable options:
 Configuration 
 -------------
 
+Default configuration is stored in `SublimeFiles.sublime-settings` accessible from _Preferences->Package Settings->Sublime Files->Settings - Default_. When changing any of the settings below it's suggested to use the user settings: _Preferences->Package Settings->Sublime Files->Settings - User_ as the file will remain untouched when updating plugin.
+
 __Ignore file types__
 
-SublimeFiles by default will ignore `*.pyc` files and `*.class` files. You can modify the list of ignored files by changing the `ignore_list` in `SublimeFiles.sublime-settings` (Preferences->Package Settings->Sublime Files->Settings - Default). For example:
+Sublime Files by default will ignore `*.pyc` files and `*.class` files. You can modify the list of ignored files by changing the `ignore_list`. For example:
 
 	{
 	    "ignore_list": ["*.pyc", "*.class", "*.o"]
@@ -41,9 +43,9 @@ SublimeFiles by default will ignore `*.pyc` files and `*.class` files. You can m
 
 __Open Terminal__
 
-For OS X/Linux systems, Sublime Files can open up a terminal at the current directory navigated to. In order for this feature to work properly, you will have to modify the `term_command` field in the `SublimeFiles.sublime-settings` file (Preferences->Package Settings->Sublime Files->Settings - Default). As a default, it is set to open up Terminal.app for OS X systems. 
+For OS X/Linux systems, Sublime Files can open up a terminal at the current directory navigated to. In order for this feature to work properly, you will have to modify the `term_command`. As a default, it is set to open up Terminal.app for OS X systems. 
 
-For example, Gnome Terminal and iTerm2 users respectively will want to change term\_command in `SublimeFiles.sublime-settings` to: 
+For example, Gnome Terminal and iTerm2 users respectively will want to change `term_command` to: 
 
 	{
 	    "term_command": "gnome-terminal --working-directory="
@@ -54,3 +56,13 @@ and
 	{
 	    "term_command" : "open -a iTerm\ 2 "
 	}
+
+__Start directory__
+
+If you _always_ want to start navigation from a given directory for example `~` just update the `start_directory` setting:
+
+	{
+	    "start_directory": "~"
+	}
+
+Default configuration comes with this setting turned off (set to `null`).

--- a/SublimeFiles.sublime-settings
+++ b/SublimeFiles.sublime-settings
@@ -6,5 +6,9 @@
     // List of Unix shell-style wildcard matches for file types to
     // ignore when listing files in the navigator.
     // By default, ignores *.pyc and *.class files.
-    "ignore_list": ["*.pyc", "*.class"]
+    "ignore_list": ["*.pyc", "*.class"],
+
+    // If provided, will always start navigation from given directory.
+    // Use "~" to point to home directory, null to disable.
+    "start_directory": "null"
 }

--- a/sublime_files.py
+++ b/sublime_files.py
@@ -32,25 +32,28 @@ class SublimeFilesCommand(sublime_plugin.WindowCommand):
                 self.home = 'USERPROFILE'
             else:
                 self.home = 'HOME'
-            try:
-                self.current_dir = os.path.dirname(sublime.active_window().active_view().file_name())
-                os.chdir(self.current_dir)
-            except:
-                self.current_dir = os.getenv(self.home)
-                os.chdir(self.current_dir)
-
             self.project_root = None
             self.bookmark = None
             self.term_command = settings.get('term_command')
             self.ignore_list = settings.get('ignore_list')
+            self.start_directory = settings.get('start_directory')
+            if self.start_directory is not None:
+                self.start_directory = os.path.abspath(os.path.expanduser(self.start_directory))
+                if not os.path.exists(self.start_directory):
+                    print ('SublimeFiles: "start_directory" points to invalid path, ignoring.')
+                    self.start_directory = None
             self.drives = []  # for windows machines
 
         if command == 'navigate':
+            if self.start_directory is not None:
+                os.chdir(self.start_directory)
+
             self.open_navigator()
 
     # function for showing panel for changing directories / opening files
     def open_navigator(self):
-        self.check_project_root()
+        if self.start_directory is None:
+            self.check_project_root()
         self.current_dir = self.getcwd()
         self.dir_files = ['[' + self.getcwd() + ']',
             bullet + ' Directory actions', '..' + os.sep, '~' + os.sep]


### PR DESCRIPTION
I tend to start navigation from my home directory, thus new configuration option. However by default it's turned off, so original behaviour still applies. 

Changes:
- new configuration option (turned off by default)
- documentation update
