### PR TITLE
Fix crash when working directory ceases to exist

### DIFF
--- a/sublime_files.py
+++ b/sublime_files.py
@@ -13,10 +13,14 @@ bullet = u'\u2022'
 class SublimeFilesCommand(sublime_plugin.WindowCommand):
 
     def getcwd(self):
-        if running_in_st3():
-            return os.getcwd()
-        else:
-            return os.getcwdu()
+        try:
+            if running_in_st3():
+                return os.getcwd()
+            else:
+                return os.getcwdu()
+        except OSError:
+            os.chdir(os.getenv(self.home))
+            return self.getcwd()
 
     def show_quick_panel(self, elements, on_selection, params):
         sublime.set_timeout(lambda: self.window.show_quick_panel(elements, on_selection, params), 10)


### PR DESCRIPTION
Here's a scenario:

```
$ cd ~
$ mkdir abc
```

Now, go into Sublime Files and navigate to `~/abc`.

```
$ rm -r abc
```

Now, go back to Sublime Text and Sublime Files will crash when you attempt to invoke it because `os.getcwd` throws an error.
