### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For OS X/Linux systems, Sublime Files can open up a terminal at the current dire
 For example, Gnome Terminal and iTerm2 users respectively will want to change `term_command` to: 
 
 	{
-	    "term_command": "gnome-terminal --working-directory="
+	    "term_command": "gnome-terminal"
 	}
 
 and


### PR DESCRIPTION
If you use "gnome-terminal --working-directory=" the terminal would be opened per Popen(["gnome-terminal" "--working-directory=", "/current/directory"]), meaning gnome-terminal receive params "--working-directory=" and "/current/directory" instead of "--working-directory=/current/directory".
