### PR TITLE
Fixed getting the wrong executable in ST3 on Linux

### DIFF
--- a/sublime_files.py
+++ b/sublime_files.py
@@ -217,7 +217,10 @@ def get_sublime_path():
         else:
             return '/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl'
     elif sublime.platform() == 'linux':
-        return open('/proc/self/cmdline').read().split(chr(0))[0]
+        if running_in_st3():
+            return open('/proc/' + str(os.getppid()) + '/cmdline').read().split(chr(0))[0]
+        else:
+            return open('/proc/self/cmdline').read().split(chr(0))[0]
     else:
         if running_in_st3():
             return os.path.join(sys.path[0], 'sublime_text.exe')


### PR DESCRIPTION
It seems that ST3 runs plugins in the plugin_host executable, so this gets the parent's executable.
